### PR TITLE
Add support for custom headers

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -170,7 +170,8 @@ class Message(object):
                  attachments=None,
                  reply_to=None,
                  date=None,
-                 charset=None):
+                 charset=None,
+                 extra_headers=None):
 
         if sender is None:
             sender = current_app.config.get("DEFAULT_MAIL_SENDER")
@@ -186,6 +187,7 @@ class Message(object):
         self.date = date
         self.msgId = make_msgid()
         self.charset = charset
+        self.extra_headers = extra_headers
 
         self.cc = cc
         self.bcc = bcc
@@ -247,6 +249,10 @@ class Message(object):
 
         if self.reply_to:
             msg['Reply-To'] = self.reply_to
+
+        if self.extra_headers:
+            for k, v in self.extra_headers.iteritems():
+                msg[k] = v
 
         for attachment in self.attachments:
             f = MIMEBase(*attachment.content_type.split('/'))

--- a/tests.py
+++ b/tests.py
@@ -276,6 +276,14 @@ class TestMessage(TestCase):
 
         self.assertIn('From: =?utf-8?b?w4TDnMOWIOKGkiDinJMgPGZyb21AZXhhbXBsZS5jb20+Pg==?=', msg.as_string())
 
+    def test_extra_headers(self):
+        msg = Message(subject="subject",
+                      recipients=["to@example.com"],
+                      body="hello",
+                      extra_headers={'X-Extra-Header': 'Yes'})
+
+        self.assertIn('X-Extra-Header: Yes', msg.as_string())
+
     def test_message_charset(self):
         msg = Message(subject="subject",
                 recipients=["foo@bar.com"],


### PR DESCRIPTION
headers can be passed as a dict to the message constructor and are passed as-is to the underlying lamson mail.
