### PR TITLE
Allow sending mails with no body.

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -292,7 +292,6 @@ class Message(object):
         """
 
         assert self.recipients, "No recipients have been added"
-        assert self.body or self.html, "No body or HTML has been set"
         assert self.sender, "No sender address has been set"
 
         if self.has_bad_headers():

--- a/tests.py
+++ b/tests.py
@@ -101,17 +101,6 @@ class TestMessage(TestCase):
 
         self.assertRaises(AssertionError, self.mail.send, msg)
 
-    def test_send_without_body(self):
-
-        msg = Message(subject="testing",
-                      recipients=["to@example.com"])
-
-        self.assertRaises(AssertionError, self.mail.send, msg)
-
-        msg.html = "<b>test</b>"
-
-        self.mail.send(msg)
-
     def test_normal_send(self):
         """
         This will not actually send a message unless the mail server


### PR DESCRIPTION
Sometimes it is desirable to send a message without body (e.g. subject and attachments only). flask-mail shouldn't block this.
