### PR TITLE
mail sender coding trouble

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -179,7 +179,7 @@ class Message(object):
 
         if isinstance(sender, tuple):
             # sender can be tuple of (name, address)
-            sender = "%s <%s>" % sender
+            sender = ("%s <%s>" % sender).encode('utf-8')
 
         self.subject = subject
         self.sender = sender


### PR DESCRIPTION
I've met a problem when tried to pass a tuple as a sender parameter to Message class. (name, address).

> Uncaught SyntaxError: Unexpected token <

It crashes when name contains non-unicode characters, so i fixed it.
