### PR TITLE
Fix for issue #36 bulk emails using MAIL_DEFAULT_SENDER 

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -54,7 +54,7 @@ class TestMessage(TestCase):
     def test_initialize(self):
         msg = Message(subject="subject",
                       recipients=["to@example.com"])
-        self.assertEqual(msg.sender, None)
+        self.assertEqual(msg.sender, self.app.extensions['mail'].default_sender)
         self.assertEqual(msg.recipients, ["to@example.com"])
 
     def test_recipients_properly_initialized(self):
@@ -402,3 +402,23 @@ class TestConnection(TestCase):
             self.assertEqual(len(outbox), 100)
             sent_msg = outbox[0]
             self.assertEqual(sent_msg.sender, self.app.extensions['mail'].default_sender)
+
+    def test_send_without_sender(self):
+        self.app.extensions['mail'].default_sender = None
+        msg = Message(subject="testing", recipients=["to@example.com"], body="testing")
+        with self.mail.connect() as conn:
+            self.assertRaises(AssertionError, conn.send, msg)
+
+    def test_send_without_recipients(self):
+        msg = Message(subject="testing",
+                      recipients=[],
+                      body="testing")
+        with self.mail.connect() as conn:
+            self.assertRaises(AssertionError, conn.send, msg)
+
+    def test_bad_header_subject(self):
+        msg = Message(subject="testing\n\r",
+                      body="testing",
+                      recipients=["to@example.com"])
+        with self.mail.connect() as conn:
+            self.assertRaises(BadHeaderError, conn.send, msg)


### PR DESCRIPTION
Added tests and fix for bulk email with MAIL_DEFAULT_SENDER.

The simple fix was to use the default_sender when the message is created, I don't know if there was a reason for changing that recently

I also noticed some message validations were not happening from Connection.send() so I moved those around also.
