### PR TITLE
Sanitized sendmail's from_addr parameter.

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -163,7 +163,7 @@ class Connection(object):
             message.date = time.time()
 
         if self.host:
-            self.host.sendmail(message.sender,
+            self.host.sendmail(sanitize_address(message.sender),
                                message.send_to,
                                message.as_string())
 


### PR DESCRIPTION
or Mail.send_message with MAIL_DEFAULT_SENDER as ('XXXX', 'no-reply@xxx.com') will raise exception: SMTPSenderRefused(501, 'mail from address must be same as authorization user', ('XXXX', 'no-reply@xxx.com'))
