### PR TITLE
set attr of state right.

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -458,7 +458,7 @@ class Mail(_MailMixin):
     def __init__(self, app=None):
         self.app = app
         if app is not None:
-            self.state = self.init_app(app)
+            self.init_app(app)
 
     def init_app(self, app):
         """Initializes your mail settings from the application settings.
@@ -484,6 +484,7 @@ class Mail(_MailMixin):
         # register extension with app
         app.extensions = getattr(app, 'extensions', {})
         app.extensions['mail'] = state
+        self.state = state
         return state
 
     def __getattr__(self, name):


### PR DESCRIPTION
When you doing this:

``` py
mail = Mail()
mail.init_app(app)
```

You will never set `state` on the instance. I don't think people would like the idea of:

``` py
mail = Mail()
mail.state = mail.init_app(app)
```
