### PR TITLE
Fix unicode attachment names

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -318,8 +318,11 @@ class Message(object):
             try:
                 attachment.filename and attachment.filename.encode('ascii')
             except UnicodeEncodeError:
+                filename = attachment.filename
+                if not PY3:
+                    filename = filename.encode('utf8')
                 f.add_header('Content-Disposition', attachment.disposition,
-                            filename=('UTF8', '', attachment.filename.encode('utf8')))
+                            filename=('UTF8', '', filename))
             else:
                 f.add_header('Content-Disposition', '%s;filename=%s' %
                              (attachment.disposition, attachment.filename))

--- a/tests.py
+++ b/tests.py
@@ -212,7 +212,7 @@ class TestMessage(TestCase):
                       recipients=["to@example.com"],
                       body="hello")
 
-        msg.attach(data="this is a test",
+        msg.attach(data=b"this is a test",
                    content_type="text/plain",
                    filename='test doc.txt')
 
@@ -223,14 +223,16 @@ class TestMessage(TestCase):
                       recipients=["to@example.com"],
                       body="hello")
 
-        msg.attach(data="this is a test",
+        msg.attach(data=b"this is a test",
                    content_type="text/plain",
                    filename=u'ünicöde ←→ ✓.txt')
 
         parsed = email.message_from_string(msg.as_string())
 
-        self.assertEqual(re.sub(r'\s+', ' ', parsed.get_payload()[1].get('Content-Disposition')),
-            'attachment; filename*="UTF8\'\'%C3%BCnic%C3%B6de%20%E2%86%90%E2%86%92%20%E2%9C%93.txt"')
+        self.assertIn(re.sub(r'\s+', ' ', parsed.get_payload()[1].get('Content-Disposition')), [
+            'attachment; filename*="UTF8\'\'%C3%BCnic%C3%B6de%20%E2%86%90%E2%86%92%20%E2%9C%93.txt"',
+            'attachment; filename*=UTF8\'\'%C3%BCnic%C3%B6de%20%E2%86%90%E2%86%92%20%E2%9C%93.txt'
+            ])
 
     def test_html_message(self):
         html_text = "<p>Hello World</p>"


### PR DESCRIPTION
It uses the notation from RFC5987 section 3.2 if the attachment name is unicode.
