### PR TITLE
Initialize self.state to None

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -468,6 +468,8 @@ class Mail(_MailMixin):
         self.app = app
         if app is not None:
             self.state = self.init_app(app)
+        else:
+            self.state = None
 
     def init_app(self, app):
         """Initializes your mail settings from the application settings.


### PR DESCRIPTION
Without initializing self.state, python will enter an eternal loop if **getattr** is called before init_app, which can very easily happen when using Flask blueprints.
