### PR TITLE
Add support for unicode characters in subject,from,reply-to

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -9,6 +9,7 @@ import time
 import re
 
 from email.header import Header
+from email import charset
 
 from flask import Flask
 from flask_mail import Mail, Message, BadHeaderError, sanitize_address
@@ -390,6 +391,64 @@ class TestMessage(TestCase):
         msg.html = None
         msg.attach(data=b"foobar", content_type='text/csv')
         self.assertIn('Content-Type: text/plain; charset="utf-8"', msg.as_string())
+
+        # unicode sender as tuple
+        msg = Message(sender=(u"送信者", "from@example.com"),
+                      subject=u"表題",
+                      recipients=["foo@bar.com"],
+                      reply_to=u"返信先 <somebody@example.com>",
+                      charset='shift_jis')  # japanese
+        self.assertIn('From: =?iso-2022-jp?', msg.as_string())
+        self.assertNotIn('From: =?utf-8?', msg.as_string())
+        self.assertIn('Subject: =?iso-2022-jp?', msg.as_string())
+        self.assertNotIn('Subject: =?utf-8?', msg.as_string())
+        self.assertIn('Reply-To: =?iso-2022-jp?', msg.as_string())
+        self.assertNotIn('Reply-To: =?utf-8?', msg.as_string())
+        self.assertIn('Content-Type: text/plain; charset="iso-2022-jp"', msg.as_string())
+
+        # unicode subject with overwrite charset
+        charset.add_charset('utf-8', charset.SHORTEST, None, 'iso-2022-jp')  # japanese
+        msg = Message(sender="from@example.com",
+                      subject=u"表題",
+                      recipients=["foo@bar.com"],
+                      charset='utf-8')
+        self.assertIn('Subject: =?iso-2022-jp?', msg.as_string())
+        self.assertNotIn('Subject: =?utf-8?', msg.as_string())
+        self.assertIn('Content-Type: text/plain; charset="iso-2022-jp"', msg.as_string())
+
+        charset.add_charset('utf-8', charset.SHORTEST, None, 'utf-8')  # set flask-mail default charset
+
+        # unicode subject sjis
+        msg = Message(sender="from@example.com",
+                      subject=u"表題",
+                      recipients=["foo@bar.com"],
+                      charset='shift_jis')  # japanese
+        self.assertIn('Subject: =?iso-2022-jp?', msg.as_string())
+        self.assertIn('Content-Type: text/plain; charset="iso-2022-jp"', msg.as_string())
+
+        # unicode subject utf-8
+        msg = Message(sender="from@example.com",
+                      subject="subject",
+                      recipients=["foo@bar.com"],
+                      charset='utf-8')
+        self.assertIn('Subject: =?utf-8?', msg.as_string())
+        self.assertIn('Content-Type: text/plain; charset="utf-8"', msg.as_string())
+
+        # ascii subject
+        msg = Message(sender="from@example.com",
+                      subject="subject",
+                      recipients=["foo@bar.com"],
+                      charset='us-ascii')
+        self.assertNotIn('Subject: =?us-ascii?', msg.as_string())
+        self.assertIn('Content-Type: text/plain; charset="us-ascii"', msg.as_string())
+
+        # default charset
+        msg = Message(sender="from@example.com",
+                      subject="subject",
+                      recipients=["foo@bar.com"])
+        self.assertNotIn('Subject: =?', msg.as_string())
+        self.assertIn('Content-Type: text/plain; charset="utf-8"', msg.as_string())
+
 
 
 class TestMail(TestCase):


### PR DESCRIPTION
Hello,

I overwrite 'utf-8' charset, and set multibyte character to Subject, From, and Reply-to.
Because iso-2022-jp is used traditionally for e-mail in Japan.

```
charset.add_charset('utf-8', charset.SHORTEST, None, 'iso-2022-jp')
msg = Message('てすと', sender=('わたくし', 'admin@testtesttest.com'),
                       reply_to='返信先 <admin@testtesttest.com>',
                       recipients=["yasunori@gotoh.me"], charset='utf-8')
msg.body = 'てすとです'
```

I expected they are encoded by 'iso-2022-jp'.

The following are the result.

charset of header was iso-2022-jp. This is just how I expected it.

```
Content-Type: text/plain; charset="iso-2022-jp"
```

But Subject, From were encoded by utf-8.

```
From: =?utf-8?b?44KP44Gf44GP44GX?= <admin@testtesttest.com>
Subject: =?utf-8?b?44OG44K544OI?=\
Reply-To: =?utf-8?b?6L+U5L+h5YWI?= <admin@testtesttest.com>
```

I think it mostly works well. Actually, I could read the mail by Gmail, Thunderbird, and iphone.
But some mobile phone's mail client can't display text encoded by utf-8. Then, some users can't read the subject of mail.

The problem is that we can't set the encoding of Header.
I tried to fix this.
