### PR TITLE
Check message.send_to instead of recipients, for BCC-only support

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -151,7 +151,7 @@ class Connection(object):
         :param message: Message instance.
         :param envelope_from: Email address to be used in MAIL FROM command.
         """
-        assert message.recipients, "No recipients have been added"
+        assert message.send_to, "No recipients have been added"
 
         assert message.sender, (
                 "The message does not specify a sender and a default sender "


### PR DESCRIPTION
This makes it possible to send a message with all recipients in Bcc.
