### PR TITLE
Fixed: sending non-ascii message in Py3k

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -341,7 +341,12 @@ class Message(object):
 
             msg.attach(f)
 
-        return msg.as_string()
+        msg_str = msg.as_string()
+        if PY3 and isinstance(msg_str, str):
+            # Force convert to bytes string
+            return msg_str.encode(self.charset or 'utf-8')
+        else:
+            return msg_str
 
     def __str__(self):
         return self.as_string()


### PR DESCRIPTION
`smtplib.SMTP.sendmail` only accept `str` in ASCII range, or `bytes`.
This fix doesn't test if all characters in `msg_str` is in ASCII range,
just a simple force conversion to `bytes`

ref:
http://docs.python.org/3.3/library/smtplib.html#smtplib.SMTP.sendmail
https://code.djangoproject.com/ticket/19186
