### PR TITLE
Convert MAIL_DEFAULT_SENDER tuple to string in Message initializer

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -249,14 +249,14 @@ class Message(object):
                  mail_options=None,
                  rcpt_options=None):
 
-        sender = sender
+        sender = sender or current_app.extensions['mail'].default_sender
 
         if isinstance(sender, tuple):
             sender = "%s <%s>" % sender
 
         self.recipients = recipients or []
         self.subject = subject
-        self.sender = sender or current_app.extensions['mail'].default_sender
+        self.sender = sender
         self.reply_to = reply_to
         self.cc = cc or []
         self.bcc = bcc or []

--- a/tests.py
+++ b/tests.py
@@ -94,6 +94,11 @@ class TestMessage(TestCase):
                       sender=("tester", "tester@example.com"))
         self.assertEqual('tester <tester@example.com>', msg.sender)
 
+    def test_default_sender_as_tuple(self):
+        self.app.extensions['mail'].default_sender = ('tester', 'tester@example.com')
+        msg = Message(subject="testing")
+        self.assertEqual('tester <tester@example.com>', msg.sender)
+
     def test_reply_to(self):
         msg = Message(subject="testing",
                       recipients=["to@example.com"],


### PR DESCRIPTION
Fixes #61
