### PR TITLE
Add Mail.init_mail function to decouple initialization

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -480,6 +480,19 @@ class Mail(_MailMixin):
         else:
             self.state = None
 
+    def init_mail(self, config, debug=False, testing=False):
+        return _Mail(
+            config.get('MAIL_SERVER', '127.0.0.1'),
+            config.get('MAIL_USERNAME'),
+            config.get('MAIL_PASSWORD'),
+            config.get('MAIL_PORT', 25),
+            config.get('MAIL_USE_TLS', False),
+            config.get('MAIL_USE_SSL', False),
+            config.get('MAIL_DEFAULT_SENDER'),
+            int(config.get('MAIL_DEBUG', debug)),
+            config.get('MAIL_MAX_EMAILS'),
+            config.get('MAIL_SUPPRESS_SEND', testing))
+
     def init_app(self, app):
         """Initializes your mail settings from the application settings.
 
@@ -488,18 +501,7 @@ class Mail(_MailMixin):
 
         :param app: Flask application instance
         """
-
-        state = _Mail(
-            app.config.get('MAIL_SERVER', '127.0.0.1'),
-            app.config.get('MAIL_USERNAME'),
-            app.config.get('MAIL_PASSWORD'),
-            app.config.get('MAIL_PORT', 25),
-            app.config.get('MAIL_USE_TLS', False),
-            app.config.get('MAIL_USE_SSL', False),
-            app.config.get('MAIL_DEFAULT_SENDER'),
-            int(app.config.get('MAIL_DEBUG', app.debug)),
-            app.config.get('MAIL_MAX_EMAILS'),
-            app.config.get('MAIL_SUPPRESS_SEND', app.testing))
+        state = self.init_mail(app.config, app.debug, app.testing)
 
         # register extension with app
         app.extensions = getattr(app, 'extensions', {})

--- a/tests.py
+++ b/tests.py
@@ -51,6 +51,18 @@ class TestCase(unittest.TestCase):
         return self.assertTrue(obj is not None)
 
 
+class TestInitialization(TestCase):
+
+    def test_init_mail(self):
+        mail = self.mail.init_mail(
+            self.app.config,
+            self.app.debug,
+            self.app.testing
+        )
+
+        self.assertEquals(self.mail.state.__dict__, mail.__dict__)
+
+
 class TestMessage(TestCase):
 
     def test_initialize(self):


### PR DESCRIPTION
This would allow to initialize a `Mail` class by just using a dictionary
with the required configuration, thus decoupling this from the _Flask_
`app` object.

``` python
config = {
    'MAIL_SERVER',
    'MAIL_USERNAME'
    (..)
}

mail = Mail()
mail.init_mail(config)
```

This is sometimes needed when using the Mail object from parts of the application where `app` is not desired to exist, such as queue tasks or delayed jobs.

This **does not** change existing interface, just adds a `init_mail` method to the `Mail` object.
