### PR TITLE
Fix sending of non-ascii mail

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -164,9 +164,17 @@ class Connection(object):
             message.date = time.time()
 
         if self.host:
+            # If message contains only ASCII characters, forward it as string;
+            # otherwise encode to bytes.
+            message_content = message.as_string()
+            try:
+                message_content.encode('ascii')
+            except UnicodeEncodeError:
+                charset = message.charset or 'utf-8'
+                message_content = message_content.encode(charset)
             self.host.sendmail(sanitize_address(envelope_from or message.sender),
                                message.send_to,
-                               message.as_string(),
+                               message_content,
                                message.mail_options,
                                message.rcpt_options)
 


### PR DESCRIPTION
Previously sending mail with non-ascii characters ended up in error
because message was passed as str instance.  However,
smtplib.SMTP.sendmail expects message to be "a string containing
characters in the ASCII range, or a byte string".  Hence, before
calling sendmail check if message can be represented as ASCII and if
not, send byte string encoded with Message.charset (or utf-8).

Example of what happens with Flask-Mail 0.9.0:

```
>> with app.app_context():
...     msg = Message('Test: very important title', recipients=['me@example.com'],body='foobar ö')
...     mail.send(msg)
... 
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File "/usr/local/lib/python3.4/site-packages/flask_mail.py", line 416, in send
    message.send(connection)
  File "/usr/local/lib/python3.4/site-packages/flask_mail.py", line 351, in send
    connection.send(self)
  File "/usr/local/lib/python3.4/site-packages/flask_mail.py", line 168, in send
    message.as_string())
  File "/usr/local/Cellar/python3/3.4.0/Frameworks/Python.framework/Versions/3.4/lib/python3.4/smtplib.py", line 752, in sendmail
    msg = _fix_eols(msg).encode('ascii')
UnicodeEncodeError: 'ascii' codec can't encode character '\xf6' in position 306: ordinal not in range(128)
```
