### PR TITLE
fix init_app

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -504,6 +504,7 @@ class Mail(_MailMixin):
         # register extension with app
         app.extensions = getattr(app, 'extensions', {})
         app.extensions['mail'] = state
+        self.state = state
         return state
 
     def __getattr__(self, name):


### PR DESCRIPTION
fixed init_app to set the state, so that `mail.init_app(app)` works instead of saying `mail = mail.init_app(app)`
