### PR TITLE
Change _MailMixin.send signature and procedure

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -429,15 +429,16 @@ class _MailMixin(object):
         finally:
             email_dispatched.disconnect(_record)
 
-    def send(self, message):
+    def send(self, message, envelope_from=None):
         """Sends a single message instance. If TESTING is True the message will
         not actually be sent.
 
         :param message: a Message instance.
+        :param envelope_from: Email address to be used in MAIL FROM command.
         """
 
         with self.connect() as connection:
-            message.send(connection)
+            connection.send(message, envelope_from)
 
     def send_message(self, *args, **kwargs):
         """Shortcut for send(msg).


### PR DESCRIPTION
1) Add the parameter `envelope_from=None` to be able to modify the envelope from
from client code. The former version had `envelope_from` parameter only in
`Connection.send` and it was impossible to call from client code without hacking
a little.

2) In order to use this parameter, the mail is sent using the `connection`
object instead of the `message` object. This also reduce one level of innecesary
indirection (`Message.send` only does `connection.send(self)`)
