### PR TITLE
Sanitize sendmail's to_addrs parameter

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -182,7 +182,7 @@ class Connection(object):
 
         if self.host:
             self.host.sendmail(sanitize_address(envelope_from or message.sender),
-                               message.send_to,
+                               list(sanitize_addresses(message.send_to)),
                                message.as_string(),
                                message.mail_options,
                                message.rcpt_options)

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'nose',
         'blinker',
         'speaklater',
+        'mock',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tests.py
+++ b/tests.py
@@ -7,6 +7,7 @@ import email
 import unittest
 import time
 import re
+import mock
 
 from email.header import Header
 from email import charset
@@ -587,3 +588,35 @@ class TestConnection(TestCase):
                       recipients=["to@example.com"])
         with self.mail.connect() as conn:
             self.assertRaises(BadHeaderError, conn.send, msg)
+
+    def test_sendmail_with_ascii_recipient(self):
+        with self.mail.connect() as conn:
+            with mock.patch.object(conn, 'host') as host:
+                msg = Message(subject="testing",
+                              sender="from@example.com",
+                              recipients=["to@example.com"],
+                              body="testing")
+                conn.send(msg)
+                host.sendmail.assert_called_once_with(
+                    "from@example.com",
+                    ["to@example.com"],
+                    msg.as_string(),
+                    msg.mail_options,
+                    msg.rcpt_options
+                )
+
+    def test_sendmail_with_non_ascii_recipient(self):
+        with self.mail.connect() as conn:
+            with mock.patch.object(conn, 'host') as host:
+                msg = Message(subject="testing",
+                              sender="from@example.com",
+                              recipients=[u'ÄÜÖ → ✓ <to@example.com>'],
+                              body="testing")
+                conn.send(msg)
+                host.sendmail.assert_called_once_with(
+                    "from@example.com",
+                    ["=?utf-8?b?w4TDnMOWIOKGkiDinJM=?= <to@example.com>"],
+                    msg.as_string(),
+                    msg.mail_options,
+                    msg.rcpt_options
+                )

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py26, py27, pypy, py33
 
 [testenv]
 deps =
+    mock
     nose
     speaklater
 


### PR DESCRIPTION
This allows sending emails to addresses containing non-ascii characters.

My problem was with code 

```
mail.send_message(recipients=[u'Pekka Pöyry <my_email@fastmonkeys.com>'], ...)
```

that failed with error `UnicodeEncodeError: 'ascii' codec can't encode characters in position 11-12: ordinal not in range(128)` inside sendmail function.
