### PR TITLE
Fix MAIL_SUPPRESS_SEND documentation bug

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -184,7 +184,7 @@ If the setting ``TESTING`` is set to ``True``, emails will be
 suppressed. Calling ``send()`` on your messages will not result in
 any messages being actually sent.
 
-Alternatively outside a testing environment you can set ``MAIL_SUPPRESS_SEND`` to **False**. This
+Alternatively outside a testing environment you can set ``MAIL_SUPPRESS_SEND`` to **True**. This
 will have the same effect.
 
 However, it's still useful to keep track of emails that would have been


### PR DESCRIPTION
I think the docs for MAIL_SUPPRESS_SEND setting has a bug. It says:

> Alternatively outside a testing environment you can set MAIL_SUPPRESS_SEND to **False**. This will have the same effect.

I think this happens when MAIL_SUPPRESS_SEND is set to **True**. At least that's what I could understand by reading the setting's name. Also, by looking at the code on [`Connection.__enter__`](https://github.com/mattupstate/flask-mail/blob/master/flask_mail.py#L140) method, it looks like this:

```
if self.mail.suppress:
    self.host = None
else:
    self.host = self.configure_host()
```

Meaning that when `self.mail.suppress == True` then the message is not gonna be delivered. At least this is what I understand. Please correct me if I'm wrong. Either way here is the very small patch to the doc in case I'm right.
