### PR TITLE
Fixes #99 - Fallbacks when trying to import policy from mail (added only on Python 3.3)

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -38,11 +38,14 @@ PY34 = PY3 and sys.version_info[1] >= 4
 if PY3:
     string_types = str,
     text_type = str
-    from email import policy
-    message_policy = policy.SMTP
 else:
     string_types = basestring,
     text_type = unicode
+
+try:
+    from email import policy
+    message_policy = policy.SMTP
+except ImportError:
     message_policy = None
 
 charset.add_charset('utf-8', charset.SHORTEST, None, 'utf-8')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy, py33
+envlist = py26, py27, pypy, pypy3, py33
 
 [testenv]
 deps =


### PR DESCRIPTION
Fixes #99 
email.policy is not available on versions prior to Python 3.3, so pypy3 throws an import error.
