### PR TITLE
Make base64 as default body encoding

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -45,7 +45,7 @@ else:
     text_type = unicode
     message_policy = None
 
-charset.add_charset('utf-8', charset.SHORTEST, None, 'utf-8')
+charset.add_charset('utf-8', charset.SHORTEST, charset.BASE64, 'utf-8')
 
 
 class FlaskMailUnicodeDecodeError(UnicodeDecodeError):

--- a/tests.py
+++ b/tests.py
@@ -369,8 +369,8 @@ class TestMessage(TestCase):
         self.assertEqual(len(body.get_payload()), 2)
 
         plain, html = body.get_payload()
-        self.assertEqual(plain.get_payload(), plain_text)
-        self.assertEqual(html.get_payload(), html_text)
+        self.assertEqual(base64.b64decode(plain.get_payload()), plain_text)
+        self.assertEqual(base64.b64decode(html.get_payload()), html_text)
         self.assertEqual(base64.b64decode(attachment.get_payload()), b'this is a test')
 
     def test_date_header(self):

--- a/tests.py
+++ b/tests.py
@@ -369,8 +369,8 @@ class TestMessage(TestCase):
         self.assertEqual(len(body.get_payload()), 2)
 
         plain, html = body.get_payload()
-        self.assertEqual(base64.b64decode(plain.get_payload()), plain_text)
-        self.assertEqual(base64.b64decode(html.get_payload()), html_text)
+        self.assertEqual(base64.b64decode(plain.get_payload()), plain_text.encode())
+        self.assertEqual(base64.b64decode(html.get_payload()), html_text.encode())
         self.assertEqual(base64.b64decode(attachment.get_payload()), b'this is a test')
 
     def test_date_header(self):


### PR DESCRIPTION
Make base64 as default body encoding, otherwise ancient mail sender/receiver servers can wrap overlong lines and potentially break the content of a mail - https://tools.ietf.org/html/rfc5322#section-2.1.1

The real broken links in the mail html body is the reason why this pull requests emerged. The default falsk-mail behaviour is currently dangerous and may result broken emails.

The `.add_chaset(` line is looking strange in there as well, as it changes the default `email.charset`'s `utf-8` body encoding defined in https://github.com/python/cpython/blob/master/Lib/email/charset.py#L63 from `BASE64` to `None`. My suggestion is to stick to the standard default defined encodings, which is the safest way, in this case the line can even be easily removed from the file. I am happy to re-submit this request with the line removed, if you do not see any backward incompatible problems with the current code.

Thanks.
