### PR TITLE
Sender tuple comma parsing

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -275,7 +275,7 @@ class Message(object):
         sender = sender or current_app.extensions['mail'].default_sender
 
         if isinstance(sender, tuple):
-            sender = "%s <%s>" % sender
+            sender = formataddr(sender)
 
         self.recipients = recipients or []
         self.subject = subject

--- a/tests.py
+++ b/tests.py
@@ -397,6 +397,13 @@ class TestMessage(TestCase):
         self.assertIsNotNone(r)
         self.assertIn('Message-ID: ' + msg.msgId, msg.as_string())
 
+    def test_comma_sender_tuple(self):
+        msg = Message(subject="subject",
+                      sender=("Foo, Bar", 'from@example.com'),
+                      recipients=["to@example.com"])
+
+        self.assertIn('From: "Foo, Bar" <from@example.com>', msg.as_string())
+
     def test_unicode_sender_tuple(self):
         msg = Message(subject="subject",
                       sender=(u"ÄÜÖ → ✓", 'from@example.com>'),


### PR DESCRIPTION
When the sender tuple's name contains a comma, this tuple is parsed incorrectly if formataddr is not used on the tuple
