### PR TITLE
Replace use of `assertEquals` method in tests

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -82,7 +82,7 @@ class TestInitialization(TestCase):
             self.app.testing
         )
 
-        self.assertEquals(self.mail.state.__dict__, mail.__dict__)
+        self.assertEqual(self.mail.state.__dict__, mail.__dict__)
 
 
 class TestMessage(TestCase):


### PR DESCRIPTION
`assertEquals` was removed in Python 3.12:

https://docs.python.org/3.11/whatsnew/3.11.html#pending-removal-in-python-3-12
