### PR TITLE
Add `minimal` environment, fix CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = py3{12,11,10,9,8}
+envlist =
+    py3{12,11,10,9,8}
+    minimal
+skip_missing_interpreters = true
 
 [testenv]
 package = wheel
@@ -9,6 +12,10 @@ use_frozen_constraints = true
 deps = -r requirements/tests.txt
 
 commands = pytest -v --tb=short --basetemp={envtmpdir} tests.py
+
+[testenv:minimal]
+deps =
+commands = python -c "from flask_mail import Mail"
 
 [testenv:update-requirements]
 base_python = 3.8


### PR DESCRIPTION
flask-debugtoolbar had a minimal test environment which just attempts to import flask-mail. Since we copied the CI files over from that, we need to have that environment defined for the build to pass.
