### PR TITLE
fix signal argument order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ Unreleased
     `importlib.metadata.version("flask-mail")` instead.
 -   Indicate that the deprecated `is_bad_headers` will be removed in the next
     version.
+-   Fix the `email_dispatched` signal to pass the current app as the sender and
+    `message` as an argument, rather than the other way around.
 
 
 ## Version 0.9.1

--- a/docs/index.md
+++ b/docs/index.md
@@ -278,12 +278,12 @@ Flask-Mail provides signalling support through a {data}`.email_dispatched`
 signal. This is sent whenever an email is dispatched (even if the email is not
 actually sent, i.e. in a testing environment).
 
-A function connecting to the {data}`.email_dispatched` signal takes a
-{class}`.Message` instance as a first argument, and the Flask app instance as an
-optional argument:
+A function connecting to the {data}`.email_dispatched` signal is sent with the
+{class}`~flask.Flask` instance as the first argument, and the {class}`.Message}`
+instance as the `message` argument.
 
 ```py
-def log_message(message, app):
+def log_message(app, message):
     app.logger.debug(message.subject)
 
 email_dispatched.connect(log_message)

--- a/src/flask_mail/__init__.py
+++ b/src/flask_mail/__init__.py
@@ -162,7 +162,7 @@ class Connection:
                 message.rcpt_options,
             )
 
-        email_dispatched.send(message, app=current_app._get_current_object())
+        email_dispatched.send(current_app._get_current_object(), message=message)
 
         self.num_emails += 1
 
@@ -456,24 +456,15 @@ class _MailMixin:
                 assert len(outbox) == 1
                 assert outbox[0].subject == "testing"
 
-        You must have blinker installed in order to use this feature.
         :versionadded: 0.4
         """
-
-        if not email_dispatched:
-            raise RuntimeError("blinker must be installed")
-
         outbox = []
 
-        def _record(message, app):
+        def record(app, message):
             outbox.append(message)
 
-        email_dispatched.connect(_record)
-
-        try:
+        with email_dispatched.connected_to(record):
             yield outbox
-        finally:
-            email_dispatched.disconnect(_record)
 
     def send(self, message):
         """Sends a single message instance. If TESTING is True the message will


### PR DESCRIPTION
The app is supposed to be the sender of the signal. The message is a keyword argument. This reverses the argument order for receivers of this signal.

continues #110
