### PR TITLE
release version 0.10.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Version 0.10.0
 
-Unreleased
+Released 2024-05-23
 
 -   Drop support for Python < 3.8.
 -   Use `pyproject.toml` for packaging metadata.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Flask-Mail"
-version = "0.10.0.dev"
+version = "0.10.0"
 description = "Flask extension for sending email"
 readme = "README.md"
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
This is the standard release process for Pallets projects. Create a PR updating the version and release date. This will show that the tests pass. Add the PR to the milestone. Create and push a tag for the version:

```
$ git tag -am 'release version 0.10.0' 0.10.0
$ git push origin 0.10.0
```

This will start the publish workflow in the PR. The sdist and wheel will be created and added to a draft GitHub release page. Edit the draft to check that the filenames look correct, and add any notes about the release.

The "publish-pypi" check will be pending. Once you are sure everything looks good. Click into it, and click the "Review pending deployments" link, which will give you a choice to approve uploading to PyPI. After doing so, merge the PR, publish the release page, and close the milestone.

Only members with the publish permission and core Pallets maintainers may approve the upload. PyPI's trusted publishing system is used so that no person needs direct access to PyPI.