### PR TITLE
add static type annotations

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,3 +36,19 @@ jobs:
           cache-dependency-path: requirements*/*.txt
       - run: pip install tox
       - run: tox run -e ${{ matrix.tox || format('py{0}', matrix.python) }}
+  typing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: '3.x'
+          cache: pip
+          cache-dependency-path: requirements*/*.txt
+      - name: cache mypy
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: ./.mypy_cache
+          key: mypy|${{ hashFiles('pyproject.toml') }}
+      - run: pip install tox
+      - run: tox run -e typing

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,12 +6,16 @@ Unreleased
 -   Use `pyproject.toml` for packaging metadata.
 -   Use `flit_core` as build backend.
 -   Apply code formatting and linting tools.
+-   Add static type annotations.
 -   Deprecate the `__version__` attribute. Use feature detection or
     `importlib.metadata.version("flask-mail")` instead.
 -   Indicate that the deprecated `is_bad_headers` will be removed in the next
     version.
 -   Fix the `email_dispatched` signal to pass the current app as the sender and
     `message` as an argument, rather than the other way around.
+-   `Attachment.data` may not be `None`.
+-   `Attachment.content_type` will be detected based on `filename` and `data`
+    and will not be `None`.
 
 
 ## Version 0.9.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     "Framework :: Flask",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
+    "Typing :: Typed",
 ]
 requires-python = ">=3.8"
 dependencies = [
@@ -75,7 +76,6 @@ select = [
     "UP",  # pyupgrade
     "W",  # pycodestyle warning
 ]
-ignore-init-module-imports = true
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,20 +4,12 @@
 #
 #    pip-compile dev.in
 #
-blinker==1.8.2
-    # via
-    #   -r typing.txt
-    #   flask
 cachetools==5.3.3
     # via tox
 cfgv==3.4.0
     # via pre-commit
 chardet==5.2.0
     # via tox
-click==8.1.7
-    # via
-    #   -r typing.txt
-    #   flask
 colorama==0.4.6
     # via tox
 distlib==0.3.8
@@ -31,38 +23,13 @@ filelock==3.14.0
     # via
     #   tox
     #   virtualenv
-flask==3.0.3
-    # via
-    #   -r typing.txt
-    #   flask-sqlalchemy
-flask-sqlalchemy==3.1.1
-    # via -r typing.txt
 identify==2.5.36
     # via pre-commit
-importlib-metadata==7.1.0
-    # via
-    #   -r typing.txt
-    #   flask
 iniconfig==2.0.0
     # via
     #   -r tests.txt
     #   -r typing.txt
     #   pytest
-itsdangerous==2.2.0
-    # via
-    #   -r typing.txt
-    #   flask
-jinja2==3.1.4
-    # via
-    #   -r typing.txt
-    #   flask
-markupsafe==2.1.5
-    # via
-    #   -r typing.txt
-    #   jinja2
-    #   werkzeug
-mock==5.1.0
-    # via -r tests.txt
 mypy==1.10.0
     # via -r typing.txt
 mypy-extensions==1.0.0
@@ -105,10 +72,6 @@ pyyaml==6.0.1
     # via pre-commit
 speaklater==1.3
     # via -r tests.txt
-sqlalchemy==2.0.30
-    # via
-    #   -r typing.txt
-    #   flask-sqlalchemy
 tomli==2.0.1
     # via
     #   -r tests.txt
@@ -119,33 +82,14 @@ tomli==2.0.1
     #   tox
 tox==4.15.0
     # via -r dev.in
-types-docutils==0.21.0.20240423
-    # via
-    #   -r typing.txt
-    #   types-pygments
-types-pygments==2.18.0.20240506
-    # via -r typing.txt
-types-setuptools==69.5.0.20240522
-    # via
-    #   -r typing.txt
-    #   types-pygments
 typing-extensions==4.11.0
     # via
     #   -r typing.txt
     #   mypy
-    #   sqlalchemy
 virtualenv==20.26.2
     # via
     #   pre-commit
     #   tox
-werkzeug==3.0.3
-    # via
-    #   -r typing.txt
-    #   flask
-zipp==3.18.2
-    # via
-    #   -r typing.txt
-    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,2 +1,1 @@
 pytest
-speaklater

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -14,7 +14,5 @@ pluggy==1.5.0
     # via pytest
 pytest==8.2.1
     # via -r tests.in
-speaklater==1.3
-    # via -r tests.in
 tomli==2.0.1
     # via pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import collections.abc as c
+
 import pytest
 from flask import Flask
 
@@ -5,7 +9,7 @@ from flask_mail import Mail
 
 
 @pytest.fixture
-def app():
+def app() -> c.Iterator[Flask]:
     app = Flask(__name__)
     app.config.update(
         {
@@ -19,5 +23,5 @@ def app():
 
 
 @pytest.fixture
-def mail(app):
+def mail(app: Flask) -> Mail:
     return Mail(app)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest
+from flask import Flask
 
 from flask_mail import BadHeaderError
+from flask_mail import Mail
 from flask_mail import Message
 
 
-def test_send_message(app, mail):
+def test_send_message(app: Flask, mail: Mail) -> None:
     with mail.record_messages() as outbox:
         with mail.connect() as conn:
             conn.send_message(
@@ -17,7 +21,7 @@ def test_send_message(app, mail):
         assert sent_msg.sender == app.extensions["mail"].default_sender
 
 
-def test_send_single(app, mail):
+def test_send_single(app: Flask, mail: Mail) -> None:
     with mail.record_messages() as outbox:
         with mail.connect() as conn:
             msg = Message(
@@ -32,7 +36,7 @@ def test_send_single(app, mail):
         assert sent_msg.sender == app.extensions["mail"].default_sender
 
 
-def test_send_many(app, mail):
+def test_send_many(app: Flask, mail: Mail) -> None:
     with mail.record_messages() as outbox:
         with mail.connect() as conn:
             for _i in range(100):
@@ -45,7 +49,7 @@ def test_send_many(app, mail):
         assert sent_msg.sender == app.extensions["mail"].default_sender
 
 
-def test_send_without_sender(app, mail):
+def test_send_without_sender(app: Flask, mail: Mail) -> None:
     app.extensions["mail"].default_sender = None
     msg = Message(subject="testing", recipients=["to@example.com"], body="testing")
     with mail.connect() as conn:
@@ -53,21 +57,21 @@ def test_send_without_sender(app, mail):
             conn.send(msg)
 
 
-def test_send_without_recipients(mail):
+def test_send_without_recipients(mail: Mail) -> None:
     msg = Message(subject="testing", recipients=[], body="testing")
     with mail.connect() as conn:
         with pytest.raises(AssertionError):
             conn.send(msg)
 
 
-def test_bad_header_subject(mail):
+def test_bad_header_subject(mail: Mail) -> None:
     msg = Message(subject="testing\n\r", body="testing", recipients=["to@example.com"])
     with mail.connect() as conn:
         with pytest.raises(BadHeaderError):
             conn.send(msg)
 
 
-def test_sendmail_with_ascii_recipient(mail):
+def test_sendmail_with_ascii_recipient(mail: Mail) -> None:
     with mail.connect() as conn:
         with mock.patch.object(conn, "host") as host:
             msg = Message(
@@ -87,7 +91,7 @@ def test_sendmail_with_ascii_recipient(mail):
             )
 
 
-def test_sendmail_with_non_ascii_recipient(mail):
+def test_sendmail_with_non_ascii_recipient(mail: Mail) -> None:
     with mail.connect() as conn:
         with mock.patch.object(conn, "host") as host:
             msg = Message(
@@ -107,7 +111,7 @@ def test_sendmail_with_non_ascii_recipient(mail):
             )
 
 
-def test_sendmail_with_ascii_body(mail):
+def test_sendmail_with_ascii_body(mail: Mail) -> None:
     with mail.connect() as conn:
         with mock.patch.object(conn, "host") as host:
             msg = Message(
@@ -127,7 +131,7 @@ def test_sendmail_with_ascii_body(mail):
             )
 
 
-def test_sendmail_with_non_ascii_body(mail):
+def test_sendmail_with_non_ascii_body(mail: Mail) -> None:
     with mail.connect() as conn:
         with mock.patch.object(conn, "host") as host:
             msg = Message(

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1,3 +1,10 @@
-def test_init_mail(app, mail):
+from __future__ import annotations
+
+from flask import Flask
+
+from flask_mail import Mail
+
+
+def test_init_mail(app: Flask, mail: Mail) -> None:
     new_mail = mail.init_mail(app.config, app.debug, app.testing)
     assert mail.state.__dict__ == new_mail.__dict__

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
+from flask import Flask
+
+from flask_mail import Mail
 from flask_mail import Message
 
 
-def test_send(app, mail):
+def test_send(app: Flask, mail: Mail) -> None:
     with mail.record_messages() as outbox:
         msg = Message(subject="testing", recipients=["tester@example.com"], body="test")
         mail.send(msg)
@@ -10,7 +15,7 @@ def test_send(app, mail):
         assert msg.sender == app.extensions["mail"].default_sender
 
 
-def test_send_message(app, mail):
+def test_send_message(app: Flask, mail: Mail) -> None:
     with mail.record_messages() as outbox:
         mail.send_message(
             subject="testing", recipients=["tester@example.com"], body="test"

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py3{12,11,10,9,8}
     style
+    typing
     docs
 skip_missing_interpreters = true
 
@@ -17,6 +18,13 @@ commands = pytest -v --tb=short --basetemp={envtmpdir} {posargs}
 deps = pre-commit
 skip_install = true
 commands = pre-commit run --all-files
+
+[testenv:typing]
+deps = -r requirements/typing.txt
+commands =
+    mypy
+    pyright
+    pyright --ignoreexternal --verifytypes flask_mail
 
 [testenv:docs]
 deps = -r requirements/docs.txt


### PR DESCRIPTION
Add static type annotation to the source and tests. Passes with mypy strict, pyright basic, and pyright `--verifytypes`. Add `py.typed` marker and classifier.

If `Attachment.data` is not given, an error is raised. The argument order is a bit weird, probalby because it makes more sense to read them in that order, but due to that `data` can be `None` in the signature, but must not be `None` when actually used.

If `Attachment.content_type` is not given, it is detected. `mimetypes.guess_type` is used on `filename` if filename is given. If that returns `None`, `text/plain` is used if `data` is a string, otherwise `application/octet-stream` is used. The code requires `content_type` to be set, but would previously just fail when building the message. This detection seemed preferrable to an error.
