### PR TITLE
Fixed vulnerability by explicitly passing an SSL context to enable server certificate verification

### DIFF
--- a/src/flask_mail/__init__.py
+++ b/src/flask_mail/__init__.py
@@ -139,7 +139,7 @@ class Connection:
         host: smtplib.SMTP | smtplib.SMTP_SSL
 
         if self.mail.use_ssl:
-            host = smtplib.SMTP_SSL(self.mail.server, self.mail.port)
+            host = smtplib.SMTP_SSL(self.mail.server, self.mail.port, context=ssl.create_default_context())
         else:
             host = smtplib.SMTP(self.mail.server, self.mail.port)
 

--- a/src/flask_mail/__init__.py
+++ b/src/flask_mail/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections.abc as c
 import re
 import smtplib
+import ssl
 import time
 import typing as t
 import unicodedata


### PR DESCRIPTION
I like to propose this change, which basically consists of explicitly passing an SSL/TLS context. Otherwise, the SMTP client does not verify the server cert. The background is explained in https://www.pentagrid.ch/en/blog/python-mail-libraries-certificate-verification/
